### PR TITLE
Fix typo in object member name ('form' > 'from')

### DIFF
--- a/src/lib/HistogramSlider.vue
+++ b/src/lib/HistogramSlider.vue
@@ -202,7 +202,7 @@ export default {
           var domain = [x.invert(extent[0]), x.invert(extent[1])];
           x.domain(domain);
           const pos = {
-            form: Math.max(domain[0], histSlider.result.from),
+            from: Math.max(domain[0], histSlider.result.from),
             to: Math.min(domain[1], histSlider.result.to)
           };
           this.$emit("finish", pos);


### PR DESCRIPTION
This change fixes a typo in the name of the first member of the 'pos' Object included in the 'change' and 'finish' events triggered when selecting a range of data using the clip tool.