### PR TITLE
Grid number fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@
       @finish="finish"
       :force-edges="false"
       :colors="['#4facfe', '#00f2fe']"
+      :grid-num="2"
     />
 
     <HistogramSlider

--- a/src/lib/HistogramSlider.vue
+++ b/src/lib/HistogramSlider.vue
@@ -172,7 +172,7 @@ export default {
         hide_from_to: this.hideFromTo,
         force_edges: this.forceEdges,
         drag_interval: this.dragInterval,
-        grid_num: this.Number,
+        grid_num: this.gridNum,
         block: this.block,
         keyboard: this.keyboard,
         prettify: this.prettify,


### PR DESCRIPTION
An incorrect (and non-existent) option was being passed to the Range object for `grid_num`. This PR corrects the `gridNum` prop to be passed correctly and updates the sample app to demonstrate the fix.